### PR TITLE
Correct CIS-2.2.1.2

### DIFF
--- a/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
+++ b/hubblestack_nova_profiles/cis/centos-7-level-1-scored-v2-2-0.yaml
@@ -212,7 +212,7 @@ grep:
         - /etc/ntp.conf:
             tag: CIS-2.2.1.2
             pattern: '^server'
-        - /etc/sysconfig/ntpd:
+        - /usr/lib/systemd/system/ntpd.service /etc/sysconf/ntpd:
             tag: CIS-2.2.1.2
             pattern: 'ntp:ntp'
       description: Ensure ntp is configured


### PR DESCRIPTION
The service can be defined to run as ntp:ntp in /usr/lib/systemd/system/ntpd.d.service or /etc/sysconf/ntpd.
Corrected to look for ntp:ntp in ether file.